### PR TITLE
feat: Add Option to Override SequenceNumber and Bypass Network Fetches

### DIFF
--- a/transaction/builder.go
+++ b/transaction/builder.go
@@ -28,13 +28,26 @@ func NewBuilder(c *client.Client) *Builder {
 }
 
 func (b *Builder) Build(ctx context.Context, sender account.AccountAddress, opts BuildOptions) (*RawTransaction, error) {
-	var acct types.AccountData
-	if err := b.c.Get(ctx, "/accounts/"+sender.Hex(), nil, &acct); err != nil {
-		return nil, fmt.Errorf("builder: fetch account: %w", err)
+	var seq uint64
+	fetchFromNetwork := true
+
+	// Check if a manual Sequence Number was pushed via options
+	// This skips the network call, preventing mempool nonce collisions on highly concurrent events
+	if opts.Options != nil && opts.Options.SequenceNumber != nil {
+		seq = *opts.Options.SequenceNumber
+		fetchFromNetwork = false
 	}
-	seq, err := strconv.ParseUint(acct.SequenceNumber, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("builder: parse sequence_number: %w", err)
+
+	if fetchFromNetwork {
+		var acct types.AccountData
+		if err := b.c.Get(ctx, "/accounts/"+sender.Hex(), nil, &acct); err != nil {
+			return nil, fmt.Errorf("builder: fetch account: %w", err)
+		}
+		var err error
+		seq, err = strconv.ParseUint(acct.SequenceNumber, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("builder: parse sequence_number: %w", err)
+		}
 	}
 
 	var gasEst types.GasEstimation

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -27,7 +27,7 @@ type CommittedTransaction struct {
 }
 
 type ViewRequest struct {
-	Function      string `json:"function"`
+	Function      string   `json:"function"`
 	TypeArguments []string `json:"type_arguments"`
 	Arguments     []any    `json:"arguments"`
 }
@@ -36,4 +36,7 @@ type TransactionOptions struct {
 	MaxGasAmount   *uint64
 	GasUnitPrice   *uint64
 	ExpirationSecs *uint64
+	// Optional override: If provided, bypasses the node's sequence number lookup
+	// to allow for high-frequency concurrent transaction processing.
+	SequenceNumber *uint64
 }


### PR DESCRIPTION
Fixes #1 

## The Problem
Currently, when constructing a transaction, the Kit strictly fetches the account's sequence number from the RPC node via GetAccountInfo. For applications that require high-frequency, concurrent transaction submissions (like Keeper bots or intensive indexers), this strict fetch creates a severe bottleneck. Multiple goroutines fetching at the same time will pull the exact same sequence number, resulting in immediate "Transaction already in mempool" collisions and transaction failures on the node.

## The Solution
This PR introduces the ability for clients to opt-out of the automatic network fetch by providing their own sequence number, empowering them to manage sequence state optimistically in memory.

